### PR TITLE
Convert plate-simulation-feedstock to v1 feedstock

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @sebhmg
+* @conda-forge/geoh5py

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,11 +31,21 @@ pkgs_dirs:
 solver: libmamba
 
 CONDARC
-mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-%H-%M-%S)
-echo > /opt/conda/conda-meta/history
-micromamba install --root-prefix ~/.conda --prefix /opt/conda \
-    --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+curl -fsSL https://pixi.sh/install.sh | bash
+export PATH="~/.pixi/bin:$PATH"
+pushd "${FEEDSTOCK_ROOT}"
+arch=$(uname -m)
+if [[ "$arch" == "x86_64" ]]; then
+  arch="64"
+fi
+sed -i.bak -e "s/platforms = .*/platforms = [\"linux-${arch}\"]/" -e "s/# __PLATFORM_SPECIFIC_ENV__ =/docker-build-linux-$arch =/" pixi.toml
+echo "Creating environment"
+PIXI_CACHE_DIR=/opt/conda pixi install --environment docker-build-linux-$arch
+pixi list
+echo "Activating environment"
+eval "$(pixi shell-hook --environment docker-build-linux-$arch)"
+mv pixi.toml.bak pixi.toml
+popd
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc
@@ -57,20 +67,16 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
 fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
-        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
-    fi
-    conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-
-    # Drop into an interactive shell
-    /bin/bash
+    echo "rattler-build currently doesn't support debug mode"
 else
-    conda-build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
-        --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
+
+    rattler-build build --recipe "${RECIPE_ROOT}" \
+     -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+     ${EXTRA_CB_OPTIONS:-} \
+     --target-platform "${HOST_PLATFORM}" \
+     --extra-meta flow_run_id="${flow_run_id:-}" \
+     --extra-meta remote_url="${remote_url:-}" \
+     --extra-meta sha="${sha:-}"
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
     # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Package license: MIT
 Summary: Specialized mesh, model and simulation for a parameterization of
 the halfspace + overburden and plate geological setting
 
-
 Development: https://github.com/MiraGeoscience/plate-simulation
 
 Current build status

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ the halfspace + overburden and plate geological setting
 
 Development: https://github.com/MiraGeoscience/plate-simulation
 
+Documentation: https://mirageoscience-plate-simulation.readthedocs-hosted.com/
+
 Current build status
 ====================
 
@@ -146,5 +148,5 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@sebhmg](https://github.com/sebhmg/)
+* [@conda-forge/geoh5py](https://github.com/orgs/conda-forge/teams/geoh5py/)
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,3 +4,5 @@ github:
 conda_build:
   error_overlinking: true
 conda_forge_output_validation: true
+conda_install_tool: pixi
+conda_build_tool: rattler-build

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,53 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: toml -*-
+
+#                             VVVVVV  minimum `pixi` version
+"$schema" = "https://pixi.sh/v0.36.0/schema/manifest/schema.json"
+
+[project]
+name = "plate-simulation-feedstock"
+version = "3.47.1"  # conda-smithy version used to generate this file
+description = "Pixi configuration for conda-forge/plate-simulation-feedstock"
+authors = ["@conda-forge/plate-simulation"]
+channels = ["conda-forge"]
+platforms = ["linux-64", "osx-64", "win-64"]
+
+[dependencies]
+conda-build = ">=24.1"
+conda-forge-ci-setup = "4.*"
+rattler-build = "*"
+
+[tasks]
+[tasks.inspect-all]
+cmd = "inspect_artifacts --all-packages"
+description = "List contents of all packages found in rattler-build build directory."
+[tasks.build]
+cmd = "rattler-build build --recipe recipe"
+description = "Build plate-simulation-feedstock directly (without setup scripts), no particular variant specified"
+[tasks."build-linux_64_"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_.yaml"
+description = "Build plate-simulation-feedstock with variant linux_64_ directly (without setup scripts)"
+[tasks."inspect-linux_64_"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_.yaml"
+description = "List contents of plate-simulation-feedstock packages built for variant linux_64_"
+
+[feature.smithy.dependencies]
+conda-smithy = "*"
+[feature.smithy.tasks.build-locally]
+cmd = "python ./build-locally.py"
+description = "Build packages locally using the same setup scripts used in conda-forge's CI"
+[feature.smithy.tasks.smithy]
+cmd = "conda-smithy"
+description = "Run conda-smithy. Pass necessary arguments."
+[feature.smithy.tasks.rerender]
+cmd = "conda-smithy rerender"
+description = "Rerender the feedstock."
+[feature.smithy.tasks.lint]
+cmd = "conda-smithy lint --conda-forge recipe"
+description = "Lint the feedstock recipe"
+
+[environments]
+smithy = ["smithy"]
+# This is a copy of default, to be enabled by build_steps.sh during Docker builds
+# __PLATFORM_SPECIFIC_ENV__ = []

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -59,4 +59,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - sebhmg
+    - conda-forge/geoh5py

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -46,6 +46,14 @@ tests:
       imports:
         - plate_simulation
       pip_check: true
+  - script:
+        - pytest --ignore=tests/version_test.py
+    requirements:
+      run:
+        - pytest
+    files:
+      source:
+        - tests/
 
 about:
   summary: |

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -11,7 +11,7 @@ package:
 
 source:
   url: https://github.com/MiraGeoscience/${{ name }}/archive/v${{ version }}.tar.gz
-  sha256: ceb6c139b7c2d855822ab33348e93d0af0f7ef4bfce163145ffda130950c9aba
+  sha256: 66c22ded2c7a7bb8afd5dc3799dbe5128b88d74cd7b7874a51ed325561436b40
 
 build:
   number: 1

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -20,7 +20,7 @@ build:
 
 requirements:
   host:
-    - python 3.10.*
+    - python ${{ python_min }}.*
     - poetry-core >=1.0.0
     - setuptools
     - pip
@@ -42,11 +42,11 @@ requirements:
 
 tests:
   - python:
+      python_version: ${{ python_min }}.*
       imports:
         - plate_simulation
       pip_check: true
 
-      python_version: ${{ python_min }}.*
 about:
   summary: |
     Specialized mesh, model and simulation for a parameterization of

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,28 +1,31 @@
-{% set name = "plate-simulation" %}
-{% set version = "0.1.1" %}
-{% set python_min = "3.10" %}
+schema_version: 1
+
+context:
+  name: plate-simulation
+  version: 0.1.1
+  python_min: 3.10
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: ${{ name|lower }}
+  version: ${{ version }}
 
 source:
-  url: https://github.com/MiraGeoscience/{{ name }}/archive/v{{ version }}.tar.gz
+  url: https://github.com/MiraGeoscience/${{ name }}/archive/v${{ version }}.tar.gz
   sha256: ceb6c139b7c2d855822ab33348e93d0af0f7ef4bfce163145ffda130950c9aba
 
 build:
-  number: 0
+  number: 1
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python 3.10.*
     - poetry-core >=1.0.0
     - setuptools
     - pip
   run:
-    - python >={{ python_min }},<3.11
+    - python >=${{ python_min }},<3.11
     # Mira packages
     - geoapps-utils >=0.4.0,<0.5.dev
     - geoh5py >=0.10.1,<0.11.dev
@@ -37,23 +40,21 @@ requirements:
     - threadpoolctl >=3.3.0,<3.4.dev
     - trimesh >=4.1.3,<4.2.dev
 
-test:
-  imports:
-    - plate_simulation
-  commands:
-    - pip check
-  requires:
-    - python {{ python_min }}
-    - pip
+tests:
+  - python:
+      imports:
+        - plate_simulation
+      pip_check: true
 
+      python_version: ${{ python_min }}.*
 about:
-  home: https://www.mirageoscience.com/mining-industry-software/geoscience-analyst/python-integration/
   summary: |
     Specialized mesh, model and simulation for a parameterization of
     the halfspace + overburden and plate geological setting
   license: MIT
   license_file: LICENSE
-  dev_url: https://github.com/MiraGeoscience/plate-simulation
+  homepage: https://www.mirageoscience.com/mining-industry-software/geoscience-analyst/python-integration/
+  repository: https://github.com/MiraGeoscience/plate-simulation
 
 extra:
   recipe-maintainers:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -55,6 +55,7 @@ about:
   license_file: LICENSE
   homepage: https://www.mirageoscience.com/mining-industry-software/geoscience-analyst/python-integration/
   repository: https://github.com/MiraGeoscience/plate-simulation
+  documentation: https://mirageoscience-plate-simulation.readthedocs-hosted.com/
 
 extra:
   recipe-maintainers:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -47,7 +47,7 @@ tests:
         - plate_simulation
       pip_check: true
   - script:
-        - pytest --ignore=tests/version_test.py
+        - pytest --ignore=tests/version_test.py --ignore=tests/runtest
     requirements:
       run:
         - pytest


### PR DESCRIPTION
This PR converts plate-simulation-feedstock to a v1 recipe and switch the conda build tool to rattler-build.
It has been automatically generated with [feedrattler v0.3.13](https://github.com/hadim/feedrattler).

Changes:
- [x] 📝 Converted `meta.yaml` to `recipe.yaml`
- [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
- [x] 🔧 Updated `conda-forge.yml` to use `rattler-build` and `pixi` (optional)
- [x] 🔢 Bumped the build number
- [x] 🐍 Applied temporary fixes for `python_min` and `python_version`
- [x] 🔄 Rerender the feedstock with conda-smithy
- [x] Ensured the license file is being packaged.
